### PR TITLE
v2.2 — Add Seplos BMS V3 Modbus RTU support

### DIFF
--- a/custom_components/home_energy_hub/__init__.py
+++ b/custom_components/home_energy_hub/__init__.py
@@ -42,6 +42,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         from .integrations.seplos_v2.coordinator import SeplosV2Coordinator
         coordinator = SeplosV2Coordinator(hass, entry)
         await coordinator.async_config_entry_first_refresh()
+    elif integration_type == "seplos_v3":
+        from .integrations.seplos_v3.coordinator import SeplosV3Coordinator
+        coordinator = SeplosV3Coordinator(hass, entry)
+        await coordinator.async_config_entry_first_refresh()
     else:
         return False
 

--- a/custom_components/home_energy_hub/config_flow.py
+++ b/custom_components/home_energy_hub/config_flow.py
@@ -141,8 +141,13 @@ class HomeEnergyHubFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             }
         )
 
+    async def async_step_config_seplos_v3(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        """Seplos BMS V3 config step (same schema as V2, different entry naming)."""
+        self._integration_type = "seplos_v3"
+        return await self.async_step_config_seplos_v2(user_input)
+
     def _get_seplos_v2_schema(self, connector_type: str, include_hidden: bool = True) -> vol.Schema:
-        """Dynamic schema for Seplos V2 with connector-specific and Seplos parameters."""
+        """Dynamic schema for Seplos with connector-specific and Seplos parameters."""
         from .const import (
             CONF_SERIAL_PORT, CONF_BAUD_RATE, DEFAULT_BAUD_RATE,
             CONF_BATTERY_ADDRESS, BATTERY_ADDRESSES,
@@ -248,6 +253,8 @@ class HomeEnergyHubOptionsFlowHandler(config_entries.OptionsFlow):
         if integration_type == "geo_ihd":
             return await self.async_step_geo_ihd(user_input)
         elif integration_type == "seplos_v2":
+            return await self.async_step_seplos_v2(user_input)
+        elif integration_type == "seplos_v3":
             return await self.async_step_seplos_v2(user_input)
         else:
             return self.async_abort(reason="not_supported")

--- a/custom_components/home_energy_hub/const.py
+++ b/custom_components/home_energy_hub/const.py
@@ -24,6 +24,11 @@ INTEGRATION_TYPES = {
         "category": "battery_systems",
         "description": "Seplos Battery Management System Version 2"
     },
+    "seplos_v3": {
+        "name": "Seplos BMS V3",
+        "category": "battery_systems",
+        "description": "Seplos Battery Management System Version 3 (Modbus RTU)"
+    },
 
 }
 

--- a/custom_components/home_energy_hub/integrations/seplos_v3/__init__.py
+++ b/custom_components/home_energy_hub/integrations/seplos_v3/__init__.py
@@ -1,0 +1,47 @@
+"""Seplos V3 integration."""
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .coordinator import SeplosV3Coordinator
+from ...const import DOMAIN
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Seplos V3 from a config entry."""
+    import logging
+    from homeassistant.helpers import device_registry as dr
+    
+    _LOGGER = logging.getLogger(__name__)
+    _LOGGER.info("Setting up Seplos V3 integration for entry: %s", entry.entry_id)
+    
+    coordinator = SeplosV3Coordinator(hass, entry)
+    await coordinator.async_config_entry_first_refresh()
+    
+    if DOMAIN not in hass.data:
+        hass.data[DOMAIN] = {}
+    hass.data[DOMAIN][entry.entry_id] = coordinator
+    
+    name_prefix = entry.data.get("name_prefix", "Seplos BMS V3")
+    
+    device_registry = dr.async_get(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={("home_energy_hub", f"seplos_v3_{entry.entry_id}")},
+        manufacturer="Seplos",
+        name=f"{name_prefix}",
+        model="V3 BMS",
+        sw_version="Unknown",
+    )
+    
+    await hass.config_entries.async_forward_entry_setups(entry, ["sensor"])
+    
+    _LOGGER.info("Seplos V3 integration setup complete")
+    return True
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    if await hass.config_entries.async_unload_platforms(entry, ["sensor"]):
+        if entry.entry_id in hass.data.get(DOMAIN, {}):
+            hass.data[DOMAIN].pop(entry.entry_id)
+        return True
+    return False

--- a/custom_components/home_energy_hub/integrations/seplos_v3/coordinator.py
+++ b/custom_components/home_energy_hub/integrations/seplos_v3/coordinator.py
@@ -1,0 +1,71 @@
+"""Data coordinator for Seplos V3."""
+
+from datetime import timedelta
+import logging
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from ...connectors import create_connector_client
+from .data_parser import build_commands_for_address, extract_data_from_message
+from ...const import CONF_INTEGRATION_TYPE
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SeplosV3Coordinator(DataUpdateCoordinator[dict[str, Any]]):
+    """Coordinator for Seplos V3 Modbus RTU."""
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        self._client = None
+        self.config_entry = entry
+        self._integration_type = entry.data[CONF_INTEGRATION_TYPE]
+        super().__init__(
+            hass, _LOGGER, name="Seplos V3",
+            update_interval=timedelta(seconds=entry.data.get("poll_interval", 30))
+        )
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        """Fetch data via Seplos V3 Modbus RTU protocol."""
+        try:
+            self._client = await create_connector_client(
+                self.hass, self.config_entry.data, self._integration_type
+            )
+
+            if not hasattr(self._client, 'send_serial_commands'):
+                raise UpdateFailed("Connector does not support sending raw commands")
+
+            # Build V3 Modbus RTU commands (PIA + PIB)
+            battery_addr = int(self.config_entry.data.get("battery_address", "0x01"), 0)
+            commands = build_commands_for_address(battery_addr)
+            _LOGGER.debug("Sending V3 commands: %s", commands)
+
+            try:
+                data = await self._client.send_serial_commands(commands)
+            except Exception:
+                # Fallback: try collect_all mode
+                if hasattr(self._client, 'send_serial_commands'):
+                    data = await self._client.send_serial_commands(commands)
+                else:
+                    raise
+
+            await self._client.close()
+
+            if not data or len(data) < 2:
+                _LOGGER.warning("Insufficient V3 data received")
+                return {}
+
+            processed = extract_data_from_message(data)
+            _LOGGER.debug("V3 data: %s", {k: v for k, v in processed.items() if not isinstance(v, (list, dict))})
+            return processed
+
+        except Exception as err:
+            if self._client:
+                try:
+                    await self._client.close()
+                except Exception:
+                    pass
+            _LOGGER.error("Seplos V3 update failed: %s", err)
+            raise UpdateFailed(f"Seplos V3 update failed: {err}")

--- a/custom_components/home_energy_hub/integrations/seplos_v3/data_parser.py
+++ b/custom_components/home_energy_hub/integrations/seplos_v3/data_parser.py
@@ -1,0 +1,275 @@
+"""Seplos V3 Modbus RTU data parser — ported from bms_connector.
+
+Credits: Christian F5UII (@f5uii) for the Modbus RTU implementation.
+"""
+
+import struct
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def modbus_crc(data: bytes) -> bytes:
+    """Calculate the Modbus RTU CRC (little-endian, 2 bytes)."""
+    crc = 0xFFFF
+    for byte in data:
+        crc ^= byte
+        for _ in range(8):
+            if crc & 0x0001:
+                crc = (crc >> 1) ^ 0xA001
+            else:
+                crc >>= 1
+    return struct.pack('<H', crc)
+
+
+def verify_crc(frame_hex: str) -> bool:
+    """Verify CRC of a received Modbus frame."""
+    try:
+        raw = bytes.fromhex(frame_hex)
+        if len(raw) < 4:
+            return False
+        payload = raw[:-2]
+        received_crc = raw[-2:]
+        expected_crc = modbus_crc(payload)
+        return received_crc == expected_crc
+    except Exception:
+        return False
+
+
+def build_read_command(addr: int, register: int, count: int) -> str:
+    """Build a Modbus RTU 0x04 (Read Input Registers) command as hex string."""
+    payload = bytes([addr, 0x04]) + struct.pack('>HH', register, count)
+    crc = modbus_crc(payload)
+    return (payload + crc).hex()
+
+
+def build_commands_for_address(battery_addr: int) -> list:
+    """Return PIA + PIB commands for a given battery address.
+
+    PIA: register 0x1000, 18 registers (0x12) — pack global data
+    PIB: register 0x1100, 26 registers (0x1A) — cell voltages + temperatures
+    """
+    cmd_pia = build_read_command(battery_addr, 0x1000, 0x12)
+    cmd_pib = build_read_command(battery_addr, 0x1100, 0x1A)
+    return [cmd_pia, cmd_pib]
+
+
+def convert_bytes_to_data(data_type: str, byte1: int, byte2: int):
+    """Convert two bytes to typed value (UINT16 or INT16)."""
+    if data_type == "UINT16":
+        return (byte1 << 8) | byte2
+    elif data_type == "INT16":
+        value = (byte1 << 8) | byte2
+        if value & 0x8000:
+            value -= 0x10000
+        return value
+    return None
+
+
+class V3PIA:
+    """Pack Info A: pack-level battery data."""
+
+    def __init__(self):
+        self.pack_voltage = 0.0
+        self.current = 0.0
+        self.remaining_capacity = 0.0
+        self.total_capacity = 0.0
+        self.total_discharge_capacity = 0.0
+        self.soc = 0.0
+        self.soh = 0.0
+        self.cycle = 0
+        self.avg_cell_voltage = 0.0
+        self.avg_cell_temperature = 0.0
+        self.max_cell_voltage = 0.0
+        self.min_cell_voltage = 0.0
+        self.max_cell_temperature = 0.0
+        self.min_cell_temperature = 0.0
+        self.max_discharge_current = 0.0
+        self.max_charge_current = 0.0
+
+
+class V3PIB:
+    """Pack Info B: cell voltages and temperatures."""
+
+    def __init__(self):
+        self.cell1_voltage = 0.0
+        self.cell2_voltage = 0.0
+        self.cell3_voltage = 0.0
+        self.cell4_voltage = 0.0
+        self.cell5_voltage = 0.0
+        self.cell6_voltage = 0.0
+        self.cell7_voltage = 0.0
+        self.cell8_voltage = 0.0
+        self.cell9_voltage = 0.0
+        self.cell10_voltage = 0.0
+        self.cell11_voltage = 0.0
+        self.cell12_voltage = 0.0
+        self.cell13_voltage = 0.0
+        self.cell14_voltage = 0.0
+        self.cell15_voltage = 0.0
+        self.cell16_voltage = 0.0
+        self.cell_temperature_1 = 0.0
+        self.cell_temperature_2 = 0.0
+        self.cell_temperature_3 = 0.0
+        self.cell_temperature_4 = 0.0
+        self.environment_temperature = 0.0
+        self.power_temperature = 0.0
+
+
+def decode_pia_response(response: str):
+    """Decode a PIA Modbus response into a V3PIA object."""
+    if not response:
+        return None
+    if response.startswith("~"):
+        response = response[1:]
+
+    if not verify_crc(response):
+        _LOGGER.warning("PIA CRC invalid for %s", response)
+
+    try:
+        raw = bytes.fromhex(response)
+    except ValueError:
+        return None
+
+    if len(raw) < 41:
+        _LOGGER.warning("PIA frame too short (%d bytes)", len(raw))
+        return None
+
+    data = raw[3:-2]
+    pia = V3PIA()
+
+    try:
+        pia.pack_voltage             = convert_bytes_to_data("UINT16", data[0],  data[1])  * 0.01
+        pia.current                  = convert_bytes_to_data("INT16",  data[2],  data[3])  * 0.01
+        pia.remaining_capacity       = convert_bytes_to_data("UINT16", data[4],  data[5])  * 0.01
+        pia.total_capacity           = convert_bytes_to_data("UINT16", data[6],  data[7])  * 0.01
+        pia.total_discharge_capacity = convert_bytes_to_data("UINT16", data[8],  data[9])  * 10
+        pia.soc                      = convert_bytes_to_data("UINT16", data[10], data[11]) * 0.1
+        pia.soh                      = convert_bytes_to_data("UINT16", data[12], data[13]) * 0.1
+        pia.cycle                    = convert_bytes_to_data("UINT16", data[14], data[15])
+        pia.avg_cell_voltage         = convert_bytes_to_data("UINT16", data[16], data[17]) * 0.001
+        pia.avg_cell_temperature     = convert_bytes_to_data("UINT16", data[18], data[19]) * 0.1 - 273.15
+        pia.max_cell_voltage         = convert_bytes_to_data("UINT16", data[20], data[21]) * 0.001
+        pia.min_cell_voltage         = convert_bytes_to_data("UINT16", data[22], data[23]) * 0.001
+        pia.max_cell_temperature     = convert_bytes_to_data("UINT16", data[24], data[25]) * 0.1 - 273.15
+        pia.min_cell_temperature     = convert_bytes_to_data("UINT16", data[26], data[27]) * 0.1 - 273.15
+        if len(data) >= 32:
+            pia.max_discharge_current = convert_bytes_to_data("UINT16", data[30], data[31])
+        if len(data) >= 34:
+            pia.max_charge_current    = convert_bytes_to_data("UINT16", data[32], data[33])
+    except IndexError:
+        return None
+
+    return pia
+
+
+def decode_pib_response(response: str):
+    """Decode a PIB Modbus response into a V3PIB object."""
+    if not response:
+        return None
+    if response.startswith("~"):
+        response = response[1:]
+
+    if not verify_crc(response):
+        _LOGGER.warning("PIB CRC invalid for %s", response)
+
+    try:
+        raw = bytes.fromhex(response)
+    except ValueError:
+        return None
+
+    if len(raw) < 57:
+        _LOGGER.warning("PIB frame too short (%d bytes)", len(raw))
+        return None
+
+    data = raw[3:-2]
+    pib = V3PIB()
+
+    try:
+        pib.cell1_voltage  = convert_bytes_to_data("UINT16", data[0],  data[1])  * 0.001
+        pib.cell2_voltage  = convert_bytes_to_data("UINT16", data[2],  data[3])  * 0.001
+        pib.cell3_voltage  = convert_bytes_to_data("UINT16", data[4],  data[5])  * 0.001
+        pib.cell4_voltage  = convert_bytes_to_data("UINT16", data[6],  data[7])  * 0.001
+        pib.cell5_voltage  = convert_bytes_to_data("UINT16", data[8],  data[9])  * 0.001
+        pib.cell6_voltage  = convert_bytes_to_data("UINT16", data[10], data[11]) * 0.001
+        pib.cell7_voltage  = convert_bytes_to_data("UINT16", data[12], data[13]) * 0.001
+        pib.cell8_voltage  = convert_bytes_to_data("UINT16", data[14], data[15]) * 0.001
+        pib.cell9_voltage  = convert_bytes_to_data("UINT16", data[16], data[17]) * 0.001
+        pib.cell10_voltage = convert_bytes_to_data("UINT16", data[18], data[19]) * 0.001
+        pib.cell11_voltage = convert_bytes_to_data("UINT16", data[20], data[21]) * 0.001
+        pib.cell12_voltage = convert_bytes_to_data("UINT16", data[22], data[23]) * 0.001
+        pib.cell13_voltage = convert_bytes_to_data("UINT16", data[24], data[25]) * 0.001
+        pib.cell14_voltage = convert_bytes_to_data("UINT16", data[26], data[27]) * 0.001
+        pib.cell15_voltage = convert_bytes_to_data("UINT16", data[28], data[29]) * 0.001
+        pib.cell16_voltage = convert_bytes_to_data("UINT16", data[30], data[31]) * 0.001
+        pib.cell_temperature_1 = convert_bytes_to_data("UINT16", data[32], data[33]) * 0.1 - 273.15
+        pib.cell_temperature_2 = convert_bytes_to_data("UINT16", data[34], data[35]) * 0.1 - 273.15
+        pib.cell_temperature_3 = convert_bytes_to_data("UINT16", data[36], data[37]) * 0.1 - 273.15
+        pib.cell_temperature_4 = convert_bytes_to_data("UINT16", data[38], data[39]) * 0.1 - 273.15
+        if len(data) >= 50:
+            pib.environment_temperature = convert_bytes_to_data("UINT16", data[48], data[49]) * 0.1 - 273.15
+        if len(data) >= 52:
+            pib.power_temperature = convert_bytes_to_data("UINT16", data[50], data[51]) * 0.1 - 273.15
+    except IndexError:
+        return None
+
+    return pib
+
+
+def extract_data_from_message(msg, config_battery_address=None):
+    """Parse PIA and PIB responses into a flat dict for the coordinator.
+
+    Returns a dict like:
+    {
+        "pack_voltage": 51.2,
+        "current": -5.0,
+        "cell1_voltage": 3.201,
+        ...
+    }
+    """
+    pia_data = None
+    pib_data = None
+
+    if not msg or len(msg) < 2:
+        _LOGGER.error("Need at least 2 response frames (PIA + PIB)")
+        return {}
+
+    for idx, response in enumerate(msg):
+        if isinstance(response, str) and response.startswith("~"):
+            response = response[1:]
+
+        if idx == 0:
+            pia_data = decode_pia_response(response)
+        elif idx == 1:
+            pib_data = decode_pib_response(response)
+
+    result = {}
+
+    if pia_data:
+        for attr in ["pack_voltage", "current", "remaining_capacity", "total_capacity",
+                      "total_discharge_capacity", "soc", "soh", "cycle",
+                      "avg_cell_voltage", "avg_cell_temperature",
+                      "max_cell_voltage", "min_cell_voltage",
+                      "max_cell_temperature", "min_cell_temperature",
+                      "max_discharge_current", "max_charge_current"]:
+            val = getattr(pia_data, attr, None)
+            if val is not None:
+                result[attr] = round(val, 3) if isinstance(val, float) else val
+
+    if pib_data:
+        for i in range(1, 17):
+            val = getattr(pib_data, f"cell{i}_voltage", None)
+            if val is not None:
+                result[f"cell{i}_voltage"] = round(val, 3)
+
+        for i in range(1, 5):
+            val = getattr(pib_data, f"cell_temperature_{i}", None)
+            if val is not None:
+                result[f"cell_temperature_{i}"] = round(val, 1)
+
+        if pib_data.environment_temperature:
+            result["environment_temperature"] = round(pib_data.environment_temperature, 1)
+        if pib_data.power_temperature:
+            result["power_temperature"] = round(pib_data.power_temperature, 1)
+
+    return result

--- a/custom_components/home_energy_hub/integrations/seplos_v3/sensor.py
+++ b/custom_components/home_energy_hub/integrations/seplos_v3/sensor.py
@@ -1,0 +1,93 @@
+"""Sensor entities for Seplos V3."""
+
+from homeassistant.components.sensor import SensorEntity, SensorDeviceClass, SensorStateClass
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.entity import DeviceInfo
+
+from ...const import DOMAIN, CONF_NAME_PREFIX
+import logging
+
+
+# V3 sensor definitions: (key, display_name, unit, device_class, state_class)
+V3_SENSORS = [
+    ("pack_voltage", "Pack Voltage", "V", SensorDeviceClass.VOLTAGE, SensorStateClass.MEASUREMENT),
+    ("current", "Current", "A", SensorDeviceClass.CURRENT, SensorStateClass.MEASUREMENT),
+    ("remaining_capacity", "Remaining Capacity", "Ah", None, SensorStateClass.MEASUREMENT),
+    ("total_capacity", "Total Capacity", "Ah", None, SensorStateClass.MEASUREMENT),
+    ("total_discharge_capacity", "Total Discharge Capacity", "Ah", None, SensorStateClass.TOTAL_INCREASING),
+    ("soc", "State of Charge", "%", SensorDeviceClass.BATTERY, SensorStateClass.MEASUREMENT),
+    ("soh", "State of Health", "%", None, SensorStateClass.MEASUREMENT),
+    ("cycle", "Cycle Count", None, None, SensorStateClass.TOTAL_INCREASING),
+    ("avg_cell_voltage", "Average Cell Voltage", "V", SensorDeviceClass.VOLTAGE, SensorStateClass.MEASUREMENT),
+    ("avg_cell_temperature", "Average Cell Temperature", "°C", SensorDeviceClass.TEMPERATURE, SensorStateClass.MEASUREMENT),
+    ("max_cell_voltage", "Max Cell Voltage", "V", SensorDeviceClass.VOLTAGE, SensorStateClass.MEASUREMENT),
+    ("min_cell_voltage", "Min Cell Voltage", "V", SensorDeviceClass.VOLTAGE, SensorStateClass.MEASUREMENT),
+    ("max_cell_temperature", "Max Cell Temperature", "°C", SensorDeviceClass.TEMPERATURE, SensorStateClass.MEASUREMENT),
+    ("min_cell_temperature", "Min Cell Temperature", "°C", SensorDeviceClass.TEMPERATURE, SensorStateClass.MEASUREMENT),
+    ("max_discharge_current", "Max Discharge Current", "A", SensorDeviceClass.CURRENT, SensorStateClass.MEASUREMENT),
+    ("max_charge_current", "Max Charge Current", "A", SensorDeviceClass.CURRENT, SensorStateClass.MEASUREMENT),
+]
+
+# Cell voltage sensors (16 cells)
+for i in range(1, 17):
+    V3_SENSORS.append((f"cell{i}_voltage", f"Cell {i} Voltage", "V", SensorDeviceClass.VOLTAGE, SensorStateClass.MEASUREMENT))
+
+# Cell temperature sensors (4 sensors)
+for i in range(1, 5):
+    V3_SENSORS.append((f"cell_temperature_{i}", f"Cell Temperature {i}", "°C", SensorDeviceClass.TEMPERATURE, SensorStateClass.MEASUREMENT))
+
+# Environment & power temperature
+V3_SENSORS.append(("environment_temperature", "Environment Temperature", "°C", SensorDeviceClass.TEMPERATURE, SensorStateClass.MEASUREMENT))
+V3_SENSORS.append(("power_temperature", "Power Temperature", "°C", SensorDeviceClass.TEMPERATURE, SensorStateClass.MEASUREMENT))
+
+
+class SeplosV3Sensor(CoordinatorEntity, SensorEntity):
+    """Sensor for Seplos V3 data."""
+
+    def __init__(self, coordinator, key: str, config_entry: ConfigEntry, sensor_def: tuple) -> None:
+        super().__init__(coordinator)
+        self._key = key
+        self.config_entry = config_entry
+
+        name_prefix = config_entry.data.get(CONF_NAME_PREFIX, "Seplos BMS V3")
+        battery_address = config_entry.data.get("battery_address", "0x00")
+        sensor_display_name = sensor_def[1]
+
+        self._attr_name = f"{name_prefix} {battery_address} {sensor_display_name}"
+        self._attr_unique_id = f"seplos_v3_{config_entry.entry_id}_{key}"
+        self._attr_native_unit_of_measurement = sensor_def[2]
+        self._attr_device_class = sensor_def[3]
+        self._attr_state_class = sensor_def[4]
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={("home_energy_hub", f"seplos_v3_{config_entry.entry_id}")},
+            name=f"{name_prefix}",
+            manufacturer="Seplos",
+            model="V3 BMS",
+            sw_version="Unknown",
+        )
+
+    @property
+    def native_value(self):
+        """Return the state of the sensor."""
+        return self.coordinator.data.get(self._key)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Seplos V3 sensors from a config entry."""
+    _LOGGER = logging.getLogger(__name__)
+    _LOGGER.debug("Setting up Seplos V3 sensors for entry: %s", entry.entry_id)
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    sensor_defs = {s[0]: s for s in V3_SENSORS}
+    sensors = [SeplosV3Sensor(coordinator, key, entry, sensor_defs[key]) for key in coordinator.data if key in sensor_defs]
+
+    _LOGGER.info("Created %d V3 sensors", len(sensors))
+    async_add_entities(sensors)

--- a/custom_components/home_energy_hub/sensor.py
+++ b/custom_components/home_energy_hub/sensor.py
@@ -45,3 +45,7 @@ async def async_setup_entry(
 
         coordinator = hass.data[DOMAIN][entry.entry_id]
         async_add_entities([SeplosV2Sensor(coordinator, key, entry) for key in coordinator.data.keys()])
+    elif integration_type == "seplos_v3":
+        from .integrations.seplos_v3.sensor import async_setup_entry as seplos_v3_async_setup_entry
+
+        await seplos_v3_async_setup_entry(hass, entry, async_add_entities)

--- a/custom_components/home_energy_hub/translations/en.json
+++ b/custom_components/home_energy_hub/translations/en.json
@@ -37,6 +37,20 @@
           "name_prefix": "Name Prefix",
           "poll_interval": "Update Frequency (seconds)"
         }
+      },
+      "config_seplos_v3": {
+        "title": "Configure Seplos BMS V3",
+        "description": "Configure the connection settings for your Seplos BMS V3 (Modbus RTU).",
+        "data": {
+          "connector_type": "Connection Type",
+          "serial_port": "Serial Port",
+          "baud_rate": "Baud Rate",
+          "host": "Host Address",
+          "port": "Port Number",
+          "battery_address": "Battery Address",
+          "name_prefix": "Name Prefix",
+          "poll_interval": "Update Frequency (seconds)"
+        }
       }
     }
   },
@@ -54,6 +68,17 @@
       "seplos_v2": {
         "title": "Configure Seplos BMS V2",
         "description": "Update your Seplos BMS V2 settings.",
+        "data": {
+          "poll_interval": "Update Frequency (seconds)",
+          "serial_port": "Serial Port",
+          "baud_rate": "Baud Rate",
+          "host": "Telnet Host Address",
+          "port": "Telnet Port Number"
+        }
+      },
+      "seplos_v3": {
+        "title": "Configure Seplos BMS V3",
+        "description": "Update your Seplos BMS V3 settings.",
         "data": {
           "poll_interval": "Update Frequency (seconds)",
           "serial_port": "Serial Port",


### PR DESCRIPTION
## v2.2

### New
- **Seplos BMS V3 support** — Modbus RTU protocol via USB-RS485 or Telnet
  - Pack Info A: voltage, current, capacity, SOC, SOH, cycle count, temperatures
  - Pack Info B: 16 cell voltages, 4 cell temperatures, environment/power temps
  - 22 sensors per entry
  - Same configuration flow as V2 (connection type, battery address, prefix)

### Credits
- Modbus RTU implementation ported from bms_connector — thanks Christian F5UII (@f5uii)

### Fixes
- V2 USB tested and working
- V3 config fully wired into config flow, options flow and translations